### PR TITLE
feat/AddressBookIdentityProvider

### DIFF
--- a/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.js
+++ b/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.js
@@ -1,0 +1,64 @@
+import AddressIdentityProvider from './AddressIdentityProvider'
+import { first, map } from 'rxjs/operators'
+import { getCacheKey } from '../utils/index'
+
+const addressBookAppIds = [
+  '0x32ec8cc9f3136797e0ae30e7bf3740905b0417b81ff6d4a74f6100f9037425de'
+  // TODO Add in App Ids for rinkeby and mainnet appIds
+]
+/**
+ * An identity provider for Address Book Entries
+ *
+ * @class AddressIdentityProvider
+ */
+export default class AddressBookIdentityProvider extends AddressIdentityProvider {
+  constructor (apps, cache) {
+    super()
+    this.apps = apps
+    this.cache = cache
+  }
+  /**
+   * Optional initialization, if required by the provider
+   */
+  async init () {
+    // no-op
+  }
+
+  /**
+   * Resolve the identity metadata for an address
+   * Should resolve to null if an identity does not exist
+   * Will return the first successful resolution                                                                                                                                                                                                                                tity could not be found
+   *
+   * @param  {string} address Address to resolve
+   * @return {Promise} Resolved metadata or rejected error
+   */
+  async resolve (address) {
+    address = address.toLowerCase()
+    const addressBookApps = await this.apps.pipe(
+      first(),
+      map(apps => apps.filter(app => addressBookAppIds.includes(app.appId)))
+    ).toPromise()
+
+    return addressBookApps.reduce(async (identity, app) => {
+      if (identity) {
+        return identity
+      }
+      const cacheKey = getCacheKey(app.proxyAddress, 'state')
+      const { entries = [] } = await this.cache.get(cacheKey)
+      const { data: entryData } = entries
+        .find(entry => entry.addr.toLowerCase() === address) || {}
+      return entryData || null
+    }, null)
+  }
+
+  /**
+   * Modify the identity metadata of an address
+   *
+   * @param  {string} address  Address to resolve
+   * @param  {Object} metadata Metadata to modify
+   * @return {Promise} Resolved success action or rejected error
+   */
+  async modify (address, metadata) {
+    throw new Error('Use the Address Book to change this label, or create your own local label')
+  }
+}

--- a/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
+++ b/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
@@ -22,8 +22,8 @@ test.before(async t => {
 
   cache = new Cache('stubbedAddressBook')
   await cache.init()
-  cache.set('0x0.state', { entries: [{ addr: '0x3', data: { name: 'testEntity' } }] })
-  cache.set('0x11.state', { entries: [{ addr: '0x3', data: { name: 'testEntity2' } }] })
+  cache.set('0x0.state', { entries: [{ addr: '0x3a', data: { name: 'testEntity' } }, { addr: '0x33', data: { name: 'testDude' } } ] })
+  cache.set('0x11.state', { entries: [{ addr: '0x3a', data: { name: 'testEntity2' } }] })
 })
 
 test.beforeEach(async t => {
@@ -33,7 +33,7 @@ test.beforeEach(async t => {
 
 test('should resolve identity from first address book in app array', async t => {
   const provider = t.context.addressBookIdentityProvider
-  const identityMetadata = await provider.resolve('0x3')
+  const identityMetadata = await provider.resolve('0x3a')
   t.is(identityMetadata.name, 'testEntity')
 })
 
@@ -46,4 +46,27 @@ test('should resolve to null for non-existent identity', async t => {
 test('should throw error on any modify attempt', async t => {
   const provider = t.context.addressBookIdentityProvider
   await t.throwsAsync(() => provider.modify('0x9', { name: 'newEntity' }))
+})
+
+test('getAll should return a combined Object containing all entries', async t => {
+  const provider = t.context.addressBookIdentityProvider
+  const allIdentities = await provider.getAll()
+  t.deepEqual(allIdentities, {
+    '0x3a': { name: 'testEntity' }, 
+    '0x33': { name: 'testDude' }
+  })
+})
+
+test('search should return an aray of results of freely matching identities', async t => {
+  t.plan(3)
+  const provider = t.context.addressBookIdentityProvider
+  let result = await provider.search('0x3a')
+  t.deepEqual(result, [ { name: 'testEntity', address: '0x3a' } ])
+
+  result = await provider.search('test')
+  t.deepEqual(result, [ { name: 'testEntity', address: '0x3a' },
+  { name: 'testDude', address: '0x33' } ])
+
+  result = await provider.search('testd')
+  t.deepEqual(result, [{ name: 'testDude', address: '0x33' } ])
 })

--- a/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
+++ b/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
@@ -22,7 +22,7 @@ test.before(async t => {
 
   cache = new Cache('stubbedAddressBook')
   await cache.init()
-  cache.set('0x0.state', { entries: [{ addr: '0x3a', data: { name: 'testEntity' } }, { addr: '0x33', data: { name: 'testDude' } } ] })
+  cache.set('0x0.state', { entries: [{ addr: '0x3a', data: { name: 'testEntity' } }, { addr: '0x33', data: { name: 'testDude' } }] })
   cache.set('0x11.state', { entries: [{ addr: '0x3a', data: { name: 'testEntity2' } }] })
 })
 
@@ -52,21 +52,22 @@ test('getAll should return a combined Object containing all entries', async t =>
   const provider = t.context.addressBookIdentityProvider
   const allIdentities = await provider.getAll()
   t.deepEqual(allIdentities, {
-    '0x3a': { name: 'testEntity' }, 
+    '0x3a': { name: 'testEntity' },
     '0x33': { name: 'testDude' }
   })
 })
 
-test('search should return an aray of results of freely matching identities', async t => {
-  t.plan(3)
+test('search should return an array of results of freely matching identities', async t => {
   const provider = t.context.addressBookIdentityProvider
   let result = await provider.search('0x3a')
   t.deepEqual(result, [ { name: 'testEntity', address: '0x3a' } ])
 
   result = await provider.search('test')
-  t.deepEqual(result, [ { name: 'testEntity', address: '0x3a' },
-  { name: 'testDude', address: '0x33' } ])
+  t.deepEqual(result, [
+    { name: 'testEntity', address: '0x3a' },
+    { name: 'testDude', address: '0x33' }
+  ])
 
   result = await provider.search('testd')
-  t.deepEqual(result, [{ name: 'testDude', address: '0x33' } ])
+  t.deepEqual(result, [{ name: 'testDude', address: '0x33' }])
 })

--- a/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
+++ b/packages/aragon-wrapper/src/identity/AddressBookIdentityProvider.test.js
@@ -1,0 +1,49 @@
+import test from 'ava'
+import Cache from '../cache'
+import { of } from 'rxjs'
+
+import { AddressBookIdentityProvider } from './index'
+let apps, cache
+test.before(async t => {
+  apps = of([
+    {
+      appId: '0x32ec8cc9f3136797e0ae30e7bf3740905b0417b81ff6d4a74f6100f9037425de',
+      proxyAddress: '0x0'
+    },
+    {
+      appId: '0x123',
+      proxyAddress: '0x1'
+    },
+    {
+      appId: '0x32ec8cc9f3136797e0ae30e7bf3740905b0417b81ff6d4a74f6100f9037425de',
+      proxyAddress: '0x11'
+    }
+  ])
+
+  cache = new Cache('stubbedAddressBook')
+  await cache.init()
+  cache.set('0x0.state', { entries: [{ addr: '0x3', data: { name: 'testEntity' } }] })
+  cache.set('0x11.state', { entries: [{ addr: '0x3', data: { name: 'testEntity2' } }] })
+})
+
+test.beforeEach(async t => {
+  t.context.addressBookIdentityProvider = new AddressBookIdentityProvider(apps, cache)
+  await t.context.addressBookIdentityProvider.init()
+})
+
+test('should resolve identity from first address book in app array', async t => {
+  const provider = t.context.addressBookIdentityProvider
+  const identityMetadata = await provider.resolve('0x3')
+  t.is(identityMetadata.name, 'testEntity')
+})
+
+test('should resolve to null for non-existent identity', async t => {
+  const provider = t.context.addressBookIdentityProvider
+  const identityMetadata = await provider.resolve('0x9')
+  t.is(identityMetadata, null)
+})
+
+test('should throw error on any modify attempt', async t => {
+  const provider = t.context.addressBookIdentityProvider
+  await t.throwsAsync(() => provider.modify('0x9', { name: 'newEntity' }))
+})

--- a/packages/aragon-wrapper/src/identity/index.js
+++ b/packages/aragon-wrapper/src/identity/index.js
@@ -1,2 +1,3 @@
 export { default as AddressIdentityProvider } from './AddressIdentityProvider'
 export { default as LocalIdentityProvider } from './LocalIdentityProvider'
+export { default as AddressBookIdentityProvider } from './AddressBookIdentityProvider'

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -946,13 +946,23 @@ export default class Aragon {
    * @param  {string} searchTerm
    * @return {Promise} Resolves with the identity or null if not found
    */
-  searchIdentities (searchTerm) {
-    const providerName = 'local' // TODO - get provider
-    const provider = this.identityProviderRegistrar.get(providerName)
-    if (provider && typeof provider.search === 'function') {
-      return provider.search(searchTerm)
-    }
-    return Promise.reject(new Error(`Provider (${providerName}) not installed`))
+  async searchIdentities (searchTerm) {
+    const providerNames = [ 'local', 'addressBook' ] // TODO - get provider
+    const resolvedResults = await Promise.all(
+      providerNames.map( (providerName) => {
+        const provider = this.identityProviderRegistrar.get(providerName)
+        if (provider && typeof provider.search === 'function') {
+          return provider.search(searchTerm)
+        }
+        return Promise.reject(new Error(`Provider (${providerName}) not installed`))
+      })
+    )
+    return  resolvedResults.reduce(
+      (combinedResults, providerResult) => {
+      return [ ...combinedResults, ...providerResult ]
+      }, 
+      []
+    )
   }
 
   /**

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -805,7 +805,7 @@ test('should init the identity providers correctly', async (t) => {
   // assert
   t.truthy(instance.identityProviderRegistrar)
   t.true(instance.identityProviderRegistrar instanceof Map)
-  t.is(instance.identityProviderRegistrar.size, 1, 'Should have only one provider')
+  t.is(instance.identityProviderRegistrar.size, 2, 'Should have only two providers')
 })
 
 test('should emit an intent when requesting address identity modification', async (t) => {

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -824,11 +824,11 @@ test('should search identities correctly', async (t) => {
     }
   ])
   await instance.cache.init()
-  await instance.cache.set('0x001.state', { 
+  await instance.cache.set('0x001.state', {
     entries: [
-      { addr: '0x789', data: { name: 'testEntity' } }, 
-      { addr: '0x456', data: { name: 'testDude' } } 
-    ] 
+      { addr: '0x789', data: { name: 'testEntity' } },
+      { addr: '0x456', data: { name: 'testDude' } }
+    ]
   })
   await instance.initIdentityProviders()
 
@@ -836,18 +836,18 @@ test('should search identities correctly', async (t) => {
   await instance.modifyAddressIdentity('0x123', { name: 'testperson' })
   await instance.modifyAddressIdentity('0x456', { name: 'testDao' })
   // assert
-  //console.log(await instance.cache.get('0x001.state'))
   let result = await instance.searchIdentities('test')
-  
-  t.deepEqual(result, [ { name: 'testperson', address: '0x123' },
-  { name: 'testDao', address: '0x456' },
-  { name: 'testEntity', address: '0x789' },
-  { name: 'testDude', address: '0x456' } ])
+
+  t.deepEqual(result, [
+    { name: 'testperson', address: '0x123' },
+    { name: 'testDao', address: '0x456' },
+    { name: 'testEntity', address: '0x789' },
+    { name: 'testDude', address: '0x456' } ])
 
   result = await instance.searchIdentities('0x456')
-  t.deepEqual(result, [ 
+  t.deepEqual(result, [
     { name: 'testDao', address: '0x456' },
-    { name: 'testDude', address: '0x456' } 
+    { name: 'testDude', address: '0x456' }
   ])
 })
 
@@ -867,11 +867,11 @@ test('should resolve identity correctly', async (t) => {
     }
   ])
   await instance.cache.init()
-  await instance.cache.set('0x001.state', { 
+  await instance.cache.set('0x001.state', {
     entries: [
-      { addr: '0x789', data: { name: 'testEntity' } }, 
-      { addr: '0x456', data: { name: 'testDude' } } 
-    ] 
+      { addr: '0x789', data: { name: 'testEntity' } },
+      { addr: '0x456', data: { name: 'testDude' } }
+    ]
   })
   await instance.initIdentityProviders()
 
@@ -879,11 +879,9 @@ test('should resolve identity correctly', async (t) => {
   await instance.modifyAddressIdentity('0x123', { name: 'testperson' })
   await instance.modifyAddressIdentity('0x456', { name: 'testDao' })
   // assert
-  //console.log(await instance.cache.get('0x001.state'))
   let result = await instance.resolveAddressIdentity('0x456')
-  console.log('wrapper result: ', result)
   t.is(result.name, 'testDao', 'should resolve to local label')
-  
+
   result = await instance.resolveAddressIdentity('0x789')
   t.is(result.name, 'testEntity', 'should resolve to address book entry')
 })


### PR DESCRIPTION
This will allow identity badges to show the names stored for addresses in the address book. 

One wrinkle: 
* With the `LocalIdentityProvider` component users are able to easily add a preferred "custom label" on top of the label resolved from the address book provider. However, the address book labels still show as "Custom Label" in the `LocalIdentityProvider` When they should show as something like "Address Book Entry"